### PR TITLE
Added styling flexibility and <div> nesting

### DIFF
--- a/src/test/scala/net/liftmodules/textile/TextileDivSpec.scala
+++ b/src/test/scala/net/liftmodules/textile/TextileDivSpec.scala
@@ -75,7 +75,7 @@ how are you?
                     </div>)
     }
 
-    "embed text with double-\\n at the end of div elements" in {
+    "embed text (with double-\\n at the end) of div elements" in {
       toHtml("""<div>
 bq[de]. hello
 how are you?
@@ -92,10 +92,34 @@ fine
                     </div>)
     }
 
-    "embed images (plus double-\\n) in div elements" in {
+    "embed text (with single-\\n at the end) of div elements" in {
+      toHtml("""<div>
+bq[de]. hello
+how are you?
+
+* foo
+* irks
+
+fine
+</div>""") must ==/(<div>
+                      <blockquote lang="de"><p>hello<br/>how are you?</p></blockquote>
+                      <ul><li>foo</li><li>irks</li></ul>
+                      <p>fine</p>
+                    </div>)
+    }
+
+    "embed images (plus double-\\n at the end) in div elements" in {
       toHtml("""<div>
 !test.jpg!
 
+</div>""") must ==/(<div>
+                      <p><img src="test.jpg" alt=""/></p>
+                    </div>)
+    }
+
+    "embed images (with single-\\n at the end) in div elements" in {
+      toHtml("""<div>
+!test.jpg!
 </div>""") must ==/(<div>
                       <p><img src="test.jpg" alt=""/></p>
                     </div>)

--- a/src/test/scala/net/liftmodules/textile/TextileSpec.scala
+++ b/src/test/scala/net/liftmodules/textile/TextileSpec.scala
@@ -40,20 +40,20 @@ class TextileSpec extends Specification {
     "deal with multi-line div" in {
       val div =
 """<div class="vcard">
-   <div class="fn">Joe Doe</div>
-   <div class="org">The Example Company</div>
-   <div class="tel">604-555-1234</div>
-   http://example.com/
- </div>"""
+<div class="fn">Joe Doe</div>
+<div class="org">The Example Company</div>
+<div class="tel">604-555-1234</div>
+http://example.com/
+</div>"""
 
       val res = toHtml(div)
 
-      res must ==/(<p><div class="vcard">
-   <div class="fn">Joe Doe</div>
-   <div class="org">The Example Company</div>
-   <div class="tel">604-555-1234</div>
-   <a href="http://example.com/">http://example.com/</a>
- </div></p>)
+      res must ==/(<div class="vcard">
+   <div class="fn"><p>Joe Doe</p></div>
+   <div class="org"><p>The Example Company</p></div>
+   <div class="tel"><p>604-555-1234</p></div>
+   <p><a href="http://example.com/">http://example.com/</a></p>
+ </div>)
     }
 
 


### PR DESCRIPTION
I have extended the TextileParser such that
- &lt;div&gt; elements can now be used as "top-level" elements and contain all other elements, including other &lt;div&gt;s
- multiple class named can be given in parentheses, as in "p(foo bar)."
- allowed to give classes/styles to li items as well.
