### PR TITLE
update README for Lift 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,26 @@ Adds support for the Textile markup format to your Lift application.
 
 To include this module in your Lift project, update your `libraryDependencies` in `build.sbt` to include:
 
-*Lift 2.6.x* for Scala 2.9 and 2.10:
+Lift 3.1.x for Scala 2.12 and 2.11:
 
-    "net.liftmodules" %% "textile_2.6" % "1.3"
+    "net.liftmodules" %% "textile_3.1" % "1.4-SNAPSHOT"
+
+*Lift 3.0.x* for Scala 2.10 and 2.11:
+
+    "net.liftmodules" %% "textile_3.0" % "1.3-SNAPSHOT"
 
 *Lift 2.6.x* for Scala 2.11:
 
     "net.liftmodules" %% "textile_2.6" % "1.3-SNAPSHOT"
 
+*Lift 2.6.x* for Scala 2.9 and 2.10:
+
+    "net.liftmodules" %% "textile_2.6" % "1.3"
+
 *Lift 2.5.x* for Scala 2.9 and 2.10:
 
     "net.liftmodules" %% "textile_2.5" % "1.3"
 
-*Lift 3.0.x* for Scala 2.10 and 2.11:
-
-    "net.liftmodules" %% "textile_3.0" % "1.3-SNAPSHOT"
 
 
 Documentation


### PR DESCRIPTION
Following on from https://github.com/liftmodules/textile/pull/9, I've added `libraryDependency` information for Lift 3.1.